### PR TITLE
Fix typo on Hashnode

### DIFF
--- a/src/data/linksData.js
+++ b/src/data/linksData.js
@@ -81,7 +81,7 @@ export const socialMediaLinks = [
   },
   {
     id: 6,
-    name: 'Hasnode',
+    name: 'Hashnode',
     url: 'https://a-sh.hashnode.dev',
     icon: <SiHashnode />,
     color: 'purple',


### PR DESCRIPTION
fix typo `Hasnode` →  `Hashnode`