### PR TITLE
Upgrade 'react-easy-emoji' to fix broken links:

### DIFF
--- a/src/data/journalData.js
+++ b/src/data/journalData.js
@@ -1,4 +1,4 @@
-import svgEmoji from '../utils/emoji';
+import emoji from 'react-easy-emoji';
 import { format, differenceInCalendarDays } from 'date-fns';
 import { todaysDate } from '../utils';
 
@@ -29,7 +29,7 @@ export const journalDays = [
     code: '',
     note: `Learning & getting deeper into Typescript through "Execute Program". Highly recommended!`,
     sub: '',
-    emoji: svgEmoji('💻'),
+    emoji: emoji('💻'),
   },
   {
     date: format(new Date('2022/6/11'), dateFormat),
@@ -38,7 +38,7 @@ export const journalDays = [
     code: '',
     note: `Any fool can write code that a computer can understand. Good programmers write code that humans can understand.`,
     sub: 'Martin Fowler',
-    emoji: svgEmoji('👀'),
+    emoji: emoji('👀'),
   },
   {
     date: format(new Date('2022/4/9'), dateFormat),
@@ -47,7 +47,7 @@ export const journalDays = [
     code: '',
     note: `Even simple questions are powerful. Asking "Why?" provokes reflection. Asking "Why not?" drives innovation.`,
     sub: 'Nathan Young',
-    emoji: svgEmoji('💬'),
+    emoji: emoji('💬'),
   },
   {
     date: format(new Date('2022/1/24'), dateFormat),
@@ -56,7 +56,7 @@ export const journalDays = [
     code: '',
     note: `Design is not just what it looks like & feels like. Design is how it works.`,
     sub: 'Steve Jobs',
-    emoji: svgEmoji('🪄'),
+    emoji: emoji('🪄'),
   },
   {
     date: format(new Date('2021/10/21'), dateFormat),
@@ -65,7 +65,7 @@ export const journalDays = [
     code: '',
     note: `Do not fear failure but rather fear not trying.`,
     sub: 'Roy T. Bennet',
-    emoji: svgEmoji('💥'),
+    emoji: emoji('💥'),
   },
   {
     date: format(new Date('2022/2/18'), dateFormat),
@@ -74,7 +74,7 @@ export const journalDays = [
     code: '',
     note: `There is no failure except in no longer trying.`,
     sub: 'Elbert Hubbard',
-    emoji: svgEmoji('💪🏼'),
+    emoji: emoji('💪🏼'),
   },
   {
     date: format(new Date('2022/1/3'), dateFormat),
@@ -83,7 +83,7 @@ export const journalDays = [
     code: '',
     note: `Fixed mindset, "I will never be smart, I'm not good at this, I give up!". Growth mindset, "Mistakes help me learn, I'll learn how to do this."`,
     sub: '',
-    emoji: svgEmoji('🙌🏼'),
+    emoji: emoji('🙌🏼'),
   },
   {
     date: format(new Date('2022/8/3'), dateFormat),
@@ -92,7 +92,7 @@ export const journalDays = [
     code: '',
     note: `To become really good at anything, you have to practice & repeat, ...until the technique becomes intuitive.`,
     sub: 'Paulo Coelho',
-    emoji: svgEmoji('🔁'),
+    emoji: emoji('🔁'),
   },
   {
     date: format(new Date('2021/7/7'), dateFormat),
@@ -101,7 +101,7 @@ export const journalDays = [
     code: '',
     note: 'Strive for Progress, Not Perfection.',
     sub: 'Dave Gray (@yesdavidgray)',
-    emoji: svgEmoji('🙏🏻'),
+    emoji: emoji('🙏🏻'),
   },
   {
     date: format(new Date('2021/4/14'), dateFormat),
@@ -110,7 +110,7 @@ export const journalDays = [
     code: '',
     note: 'To be an effective programmer, you need to get used to seeing errors.',
     sub: 'Alex B (Coder Academy Educator)',
-    emoji: svgEmoji('🚫'),
+    emoji: emoji('🚫'),
   },
   {
     date: format(new Date('2022/5/2'), dateFormat),
@@ -119,7 +119,7 @@ export const journalDays = [
     code: '',
     note: `The feeling of confusion (about an explanation of a new concept) is your friend, it means you're learning!`,
     sub: 'MPJME (Fun Fun Function)',
-    emoji: svgEmoji('🤨'),
+    emoji: emoji('🤨'),
   },
   {
     date: format(new Date('2022/4/11'), dateFormat),
@@ -127,7 +127,7 @@ export const journalDays = [
     tag: tags.mo,
     code: '',
     note: 'Published the first tech related blog article on Hashnode!',
-    emoji: svgEmoji('📡'),
+    emoji: emoji('📡'),
   },
   {
     date: format(new Date('2021/3/22'), dateFormat),
@@ -135,7 +135,7 @@ export const journalDays = [
     tag: tags.mo,
     code: '',
     note: 'Start of coding journey!',
-    emoji: svgEmoji('🔰'),
+    emoji: emoji('🔰'),
   },
   {
     date: format(new Date('2022/4/1'), dateFormat),
@@ -143,7 +143,7 @@ export const journalDays = [
     tag: tags.ac,
     code: '',
     note: 'Officially graduated from Coder Academy & formally obtained a Diploma of IT.',
-    emoji: svgEmoji('🎖'),
+    emoji: emoji('🎖'),
   },
   {
     date: format(new Date('2021/4/25'), dateFormat),
@@ -151,7 +151,7 @@ export const journalDays = [
     tag: tags.ac,
     code: '',
     note: 'Built the first HTML5 & SCSS only portfolio.',
-    emoji: svgEmoji('🤩'),
+    emoji: emoji('🤩'),
   },
   {
     date: format(new Date('2022/5/17'), dateFormat),
@@ -159,7 +159,7 @@ export const journalDays = [
     tag: tags.ac,
     code: '',
     note: 'Grateful to be part of making a positive impact in healthcare as an Associate Software Engineer at Seer.',
-    emoji: svgEmoji('✨'),
+    emoji: emoji('✨'),
   },
   {
     date: format(new Date('2022/2/24'), dateFormat),
@@ -167,7 +167,7 @@ export const journalDays = [
     tag: tags.ic,
     code: 'TypeScript',
     note: 'The superset of JS, with Types features to improve JS codes readability & validations.',
-    emoji: svgEmoji('🤓'),
+    emoji: emoji('🤓'),
   },
   {
     date: format(new Date('2021/3/30'), dateFormat),
@@ -175,7 +175,7 @@ export const journalDays = [
     tag: tags.ic,
     code: 'scss',
     note: 'Extremely helpful CSS preprocessor to manage CSS with additional programmatic features.',
-    emoji: svgEmoji('😍'),
+    emoji: emoji('😍'),
   },
   {
     date: format(new Date('2021/4/28'), dateFormat),
@@ -183,7 +183,7 @@ export const journalDays = [
     tag: tags.ic,
     code: 'ruby',
     note: 'First OOP language to learn. Simple, clean & (almost) everything is an object in Ruby.',
-    emoji: svgEmoji('🤓'),
+    emoji: emoji('🤓'),
   },
   {
     date: format(new Date('2021/5/27'), dateFormat),
@@ -191,7 +191,7 @@ export const journalDays = [
     tag: tags.ac,
     code: '',
     note: 'Built the first Ruby Terminal App.',
-    emoji: svgEmoji('🥳'),
+    emoji: emoji('🥳'),
   },
   {
     date: format(new Date('2021/5/31'), dateFormat),
@@ -199,7 +199,7 @@ export const journalDays = [
     tag: tags.ic,
     code: 'ruby on rails',
     note: 'Quick full-stack Ruby framework that compress the complexity of modern web apps.',
-    emoji: svgEmoji('🚂'),
+    emoji: emoji('🚂'),
   },
   {
     date: format(new Date('2022/3/20'), dateFormat),
@@ -207,7 +207,7 @@ export const journalDays = [
     tag: tags.ic,
     code: 'React TypeScript',
     note: `The more "type"ing is (actually) useful for validations & maintainability.`,
-    emoji: svgEmoji('😋'),
+    emoji: emoji('😋'),
   },
   {
     date: format(new Date('2022/6/13'), dateFormat),
@@ -215,7 +215,7 @@ export const journalDays = [
     tag: tags.ic,
     code: 'AWS Developer',
     note: 'Group training to improve team collaboration & to succeed in the exams.',
-    emoji: svgEmoji('📚'),
+    emoji: emoji('📚'),
   },
   {
     date: format(new Date('2022/3/25'), dateFormat),
@@ -223,7 +223,7 @@ export const journalDays = [
     tag: tags.wi,
     code: '',
     note: 'Pair programming with a Senior Dev friend to learn TypeScript integration with React by building a simple todo app.',
-    emoji: svgEmoji('📋'),
+    emoji: emoji('📋'),
   },
   {
     date: format(new Date('2021/6/14'), dateFormat),
@@ -231,7 +231,7 @@ export const journalDays = [
     tag: tags.ex,
     code: 'postgresql',
     note: `Relational database. It's quite complex to setup, but great for handling complex data.`,
-    emoji: svgEmoji('👥'),
+    emoji: emoji('👥'),
   },
   {
     date: format(new Date('2022/5/19'), dateFormat),
@@ -239,7 +239,7 @@ export const journalDays = [
     tag: tags.ex,
     code: 'storybook.js',
     note: 'Great tool for building UI components in isolation, esp. for a team collaboration.',
-    emoji: svgEmoji('📕'),
+    emoji: emoji('📕'),
   },
   {
     date: format(new Date('2021/6/22'), dateFormat),
@@ -247,7 +247,7 @@ export const journalDays = [
     tag: tags.ex,
     code: 'bootstrap',
     note: `Certainly helps style clean UI faster, can be customised too.`,
-    emoji: svgEmoji('😎'),
+    emoji: emoji('😎'),
   },
   {
     date: format(new Date('2021/8/17'), dateFormat),
@@ -255,7 +255,7 @@ export const journalDays = [
     tag: tags.mo,
     code: '',
     note: `First debut posting a question at Stack Overflow.`,
-    emoji: svgEmoji('🙈'),
+    emoji: emoji('🙈'),
   },
   {
     date: format(new Date('2021/8/19'), dateFormat),
@@ -263,7 +263,7 @@ export const journalDays = [
     tag: tags.ac,
     code: '',
     note: `Built the first Ruby on Rails marketplace app.`,
-    emoji: svgEmoji('😆'),
+    emoji: emoji('😆'),
   },
   {
     date: format(new Date('2021/8/23'), dateFormat),
@@ -271,7 +271,7 @@ export const journalDays = [
     tag: tags.ic,
     code: 'Javascript',
     note: `Compared to Ruby, this "only built in 10 days" language has many gotchas to be aware of.`,
-    emoji: svgEmoji('🙄'),
+    emoji: emoji('🙄'),
   },
   {
     date: format(new Date('2022/11/11'), dateFormat),
@@ -279,7 +279,7 @@ export const journalDays = [
     tag: tags.ex,
     code: 'Knex.js',
     note: `"Batteries included" PostgresSQL (& other SQLs) query builder, flexible, portable, & fun to use.`,
-    emoji: svgEmoji('🔋'),
+    emoji: emoji('🔋'),
   },
   {
     date: format(new Date('2022/3/18'), dateFormat),
@@ -287,7 +287,7 @@ export const journalDays = [
     tag: tags.ex,
     code: 'GraphQL',
     note: `APIs query language to get requests on multiple aspects of that query in one request.`,
-    emoji: svgEmoji('⚙️'),
+    emoji: emoji('⚙️'),
   },
   {
     date: format(new Date('2021/9/1'), dateFormat),
@@ -295,7 +295,7 @@ export const journalDays = [
     tag: tags.ex,
     code: 'Node.js',
     note: `Taking JavaScript beyond web browser development.`,
-    emoji: svgEmoji('🤔'),
+    emoji: emoji('🤔'),
   },
   {
     date: format(new Date('2021/9/28'), dateFormat),
@@ -303,7 +303,7 @@ export const journalDays = [
     tag: tags.ic,
     code: 'React.js',
     note: `Amazing JavaScript library! Component based UI building made easy with state management.`,
-    emoji: svgEmoji('😳'),
+    emoji: emoji('😳'),
   },
   {
     date: format(new Date('2021/10/12'), dateFormat),
@@ -311,7 +311,7 @@ export const journalDays = [
     tag: tags.ex,
     code: 'Styled-components',
     note: `At first I hated it. But in fact, very helpful to combine both CSS & JS to style UI.`,
-    emoji: svgEmoji('💅🏼'),
+    emoji: emoji('💅🏼'),
   },
   {
     date: format(new Date('2021/11/6'), dateFormat),
@@ -319,7 +319,7 @@ export const journalDays = [
     tag: tags.ex,
     code: 'MERN',
     note: `Hope to get deeper in each of the stack, esp. MongoDB & Express.js.`,
-    emoji: svgEmoji('🌞'),
+    emoji: emoji('🌞'),
   },
   {
     date: format(new Date('2021/12/2'), dateFormat),
@@ -327,7 +327,7 @@ export const journalDays = [
     tag: tags.wi,
     code: '',
     note: `First group project & Git collaboration.`,
-    emoji: svgEmoji('🤝'),
+    emoji: emoji('🤝'),
   },
   {
     date: format(new Date('2021/12/3'), dateFormat),
@@ -335,7 +335,7 @@ export const journalDays = [
     tag: tags.mo,
     code: '',
     note: `Really trying to embrace "learning by doing" as a team despite not (fully) understanding everything...`,
-    emoji: svgEmoji('🔥'),
+    emoji: emoji('🔥'),
   },
   {
     date: format(new Date('2022/3/22'), dateFormat),
@@ -343,7 +343,7 @@ export const journalDays = [
     tag: tags.mo,
     code: '',
     note: `Celebrating a year of coding journey.`,
-    emoji: svgEmoji('🧁'),
+    emoji: emoji('🧁'),
   },
   {
     date: format(new Date('2022/2/16'), dateFormat),
@@ -351,7 +351,7 @@ export const journalDays = [
     tag: tags.mo,
     code: '',
     note: `a-sh.cc is finally live!`,
-    emoji: svgEmoji('🎉'),
+    emoji: emoji('🎉'),
   },
   {
     date: format(new Date('2021/12/10'), dateFormat),
@@ -359,7 +359,7 @@ export const journalDays = [
     tag: tags.ex,
     code: 'material ui',
     note: `A level up from Bootstrap. Customisable CSS-in-JS based for styling UI with a lot of interactivity.`,
-    emoji: svgEmoji('😳'),
+    emoji: emoji('😳'),
   },
   {
     date: format(new Date('2021/12/26'), dateFormat),
@@ -367,7 +367,7 @@ export const journalDays = [
     tag: tags.ic,
     code: 'next.js',
     note: `React.js framework that enables server-side rendering & generate static websites.`,
-    emoji: svgEmoji('👍🏼'),
+    emoji: emoji('👍🏼'),
   },
   {
     date: format(new Date('2021/12/27'), dateFormat),
@@ -375,7 +375,7 @@ export const journalDays = [
     tag: tags.wi,
     code: '',
     note: `Revamping portfolio website using Next.js.`,
-    emoji: svgEmoji('😱'),
+    emoji: emoji('😱'),
   },
   {
     date: format(new Date('2021/12/31'), dateFormat),
@@ -383,7 +383,7 @@ export const journalDays = [
     tag: tags.ac,
     code: '',
     note: `End of 2021 → Total of 577 GitHub contributions so far.`,
-    emoji: svgEmoji('🐙'),
+    emoji: emoji('🐙'),
   },
   {
     date: format(new Date('2022/1/18'), dateFormat),
@@ -391,7 +391,7 @@ export const journalDays = [
     tag: tags.ac,
     code: '',
     note: `Completed Coder Academy Full-stack boot camp.`,
-    emoji: svgEmoji('🎊'),
+    emoji: emoji('🎊'),
   },
   {
     date: format(new Date('2022/1/20'), dateFormat),
@@ -399,7 +399,7 @@ export const journalDays = [
     tag: tags.wi,
     code: '',
     note: `Revisiting & re-exploring Vanilla JavaScript.`,
-    emoji: svgEmoji('🤯'),
+    emoji: emoji('🤯'),
   },
   {
     date: format(new Date('2022/1/21'), dateFormat),
@@ -407,7 +407,7 @@ export const journalDays = [
     tag: tags.ex,
     code: 'tailwind css',
     note: `Extremely fast utility first CSS framework. Very customisable.`,
-    emoji: svgEmoji('🥰'),
+    emoji: emoji('🥰'),
   },
   {
     date: format(new Date('2022/1/26'), dateFormat),
@@ -415,7 +415,7 @@ export const journalDays = [
     tag: tags.ex,
     code: 'twin.macro',
     note: `Blends the magic of Tailwind CSS & CSS-in-JS. Getting the best of both utilities!`,
-    emoji: svgEmoji('🔗'),
+    emoji: emoji('🔗'),
   },
   {
     date: format(new Date('2022/5/23'), dateFormat),
@@ -423,6 +423,6 @@ export const journalDays = [
     tag: tags.ex,
     code: 'Jest & RTL',
     note: `Deepening unit testing practice with Jest & React Testing Library. Testing is crucial, indeed!`,
-    emoji: svgEmoji('🧪'),
+    emoji: emoji('🧪'),
   },
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -3325,9 +3325,9 @@ react-dom@18.1.0:
     scheduler "^0.22.0"
 
 react-easy-emoji@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/react-easy-emoji/-/react-easy-emoji-1.6.1.tgz#72a3b6ef1e327d937a865c3795d400d0a178b706"
-  integrity sha512-VCGm1tAAdOCNVh6j+M1KoWZn4FIXcqdnf0rXINo0Sgo7eF2sat/JhITKFl8PmbpfIYqYLOobpFDVpst4ddJUlw==
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/react-easy-emoji/-/react-easy-emoji-1.8.1.tgz#29fce29ca03fe0e4976f9e3ff2beb984c69f45f1"
+  integrity sha512-wAf2x+cjwtOlLfXnjc0J3k5B2PDZdoxd1BjtfKr5tq2AL7t2ygvByJQWgFOyN28xg3qe8EKBM6pKxGP+qrGWuQ==
   dependencies:
     string-replace-to-array "^2.1.0"
 


### PR DESCRIPTION
  - Replace `svgEmoji` with the standard `emoji` for .png files since maxcdn baseUrl now only supports .png files (maxcdn host is down)